### PR TITLE
Temporarily ignore breaking ESLINT rule until it can be addressed

### DIFF
--- a/eslint.specs.js
+++ b/eslint.specs.js
@@ -29,8 +29,11 @@ module.exports = {
         'linebreak-style': [
             0, 'windows',
         ],
-        'object-curly-spacing': [
-            0, 'never',
+        'object-curly-newline': [
+            2,
+            {
+                minProperties: 1,
+            },
         ],
         'react/no-did-mount-set-state': 0,
     },

--- a/src/Lookup/Lookup.js
+++ b/src/Lookup/Lookup.js
@@ -1,3 +1,5 @@
+// TODO: Fix the instances in this file that break the rule below and remove the disabling of this rule for this file.
+/* eslint-disable no-underscore-dangle */
 import React, {Component, PropTypes} from 'react';
 import _ from 'underscore';
 import {darken, toRgbaString} from '@andrew-codes/color-functions';


### PR DESCRIPTION
- also patched up a rule for ESLINT over tests